### PR TITLE
Fix `stalwart_additional_configs` config name typo in backwards-compatible fashion

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Install & configure stalwart email server
 
 - [Requirements](#requirements)
 - [Default Variables](#default-variables)
-  - [stalwart_additionnal_configs](#stalwart_additionnal_configs)
+  - [stalwart_additional_configs](#stalwart_additional_configs)
   - [stalwart_component](#stalwart_component)
   - [stalwart_directory_options](#stalwart_directory_options)
   - [stalwart_directory_type](#stalwart_directory_type)
@@ -38,22 +38,25 @@ Install & configure stalwart email server
 
 ## Default Variables
 
-### stalwart_additionnal_configs
+### stalwart_additional_configs
 
-Stalwart additionnal configuration
+Stalwart additional configuration
+
+`stalwart_additionnal_configs` is deprecated. The role still accepts it for compatibility,
+but new configurations should use `stalwart_additional_configs`.
 
 **_Type:_** list<br />
 
 #### Default value
 
 ```YAML
-stalwart_additionnal_configs: []
+stalwart_additional_configs: []
 ```
 
 #### Example usage
 
 ```YAML
-stalwart_additionnal_configs:
+stalwart_additional_configs:
   - name: "directory.imap.pool"
     options:
       max-connections: 10

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -167,12 +167,12 @@ stalwart_tracers:
       ansi: false
       enable: true
 
-# @var stalwart_additionnal_configs
-# @var stalwart_additionnal_configs:type: list
-# @var stalwart_additionnal_configs:description: >
-# Stalwart additionnal configuration
-# @var stalwart_additionnal_configs:example: >
-# stalwart_additionnal_configs:
+# @var stalwart_additional_configs
+# @var stalwart_additional_configs:type: list
+# @var stalwart_additional_configs:description: >
+# Stalwart additional configuration
+# @var stalwart_additional_configs:example: >
+# stalwart_additional_configs:
 #   - name: "directory.imap.pool"
 #     options:
 #       max-connections: 10
@@ -181,4 +181,4 @@ stalwart_tracers:
 #       create: "30s"
 #       wait: "30s"
 #       recycle: "30s"
-stalwart_additionnal_configs: []
+stalwart_additional_configs: "{{ stalwart_additionnal_configs | default([]) }}"

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -37,7 +37,7 @@
         protocol: "http"
         bind: "[::]:8080"
 
-    stalwart_additionnal_configs:
+    stalwart_additional_configs:
       - name: "directory.imap.pool"
         options:
           max-connections: 10

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -37,6 +37,17 @@
         path: "/opt/stalwart/etc/config.toml"
       register: "st_config"
 
+    - name: "Define deprecated additional config variable"
+      ansible.builtin.set_fact:
+        stalwart_additionnal_configs:
+          - name: "legacy.compat"
+            options:
+              max-connections: 42
+
+    - name: "Load role defaults"
+      ansible.builtin.include_vars:
+        file: "{{ playbook_dir }}/../../defaults/main.yml"
+
     - name: "Gather facts on listening ports"
       community.general.listen_ports_facts:
 
@@ -55,5 +66,6 @@
           - (ansible_facts.tcp_listen | selectattr('port', 'equalto', 143) | length ) == 0
           - (ansible_facts.tcp_listen | selectattr('port', 'equalto', 110) | length ) == 0
           - (ansible_facts.tcp_listen | selectattr('port', 'equalto', 4190) | length ) == 0
+          - stalwart_additional_configs == stalwart_additionnal_configs
         success_msg: "All assertions passed!"
         fail_msg: "Some assertions failed!"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -6,6 +6,13 @@
   become: true
   become_user: "{{ stalwart_system_user }}"
 
+- name: "Warn about deprecated additional config variable"
+  ansible.builtin.debug:
+    msg: >-
+      'stalwart_additionnal_configs' is deprecated and will be removed in a future release.
+      Use 'stalwart_additional_configs' instead.
+  when: stalwart_additionnal_configs is defined
+
 - name: "Setup configuration"
   ansible.builtin.template:
     src: "opt/stalwart/etc/config.toml.j2"

--- a/templates/opt/stalwart/etc/config.toml.j2
+++ b/templates/opt/stalwart/etc/config.toml.j2
@@ -76,13 +76,13 @@ user = "{{ stalwart_fallback_admin_login }}"
 secret = "{{ stalwart_fallback_admin_password | ansible.builtin.password_hash(salt=stalwart_fallback_admin_password_salt, rounds=5000) }}"
 
 
-{% for config in stalwart_additionnal_configs | default([]) %}
+{% for config in stalwart_additional_configs | default([]) %}
 [{{ config.name }}]
 {% for option_name, option_value in (config.options | default({})).items() %}
 {{ option_name }} =
 {%- if option_value is string %}
  "{{ option_value }}"
-{% elif value is boolean %}
+{% elif option_value is boolean %}
  {{ option_value | lower }}
 {% else %}
  {{ option_value }}


### PR DESCRIPTION
## Proposed changes

This PR fixes a typo in `stalwart_additional_configs` in a backwards-compatible fashion.

## Types of changes

What types of changes does your code introduce ?

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [ ] I have labeled this PR
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
